### PR TITLE
Update PHP_CodeSniffer repository link and schema URL

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -3,7 +3,7 @@
     name="WordPress-LSX-Design"
     namespace="WordPressCS\WordPress"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd"
 >
     <description>WordPress Coding Standards for HTML and PHP files in the project.</description>
     

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This software uses the following open source packages:
 * [WebPack](https://webpackwebpack.js.org/)
 * [Gulp](https://gulpjs.com/)
 * [Node.js](https://nodejs.org/)
-* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+* [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)
 * [Font Awesome](http://fontawesome.io/) icons are licensed under the terms of the SIL OFL 1.1, and code licensed under the terms of MIT License.
 * [Modernizr](https://modernizr.com/) is licensed under the terms of the MIT license.
 * [imagesLoaded](http://imagesloaded.desandro.com/) is licensed under the terms of the MIT license.


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

Additionally, PHP_CodeSniffer now provides a canonical permalink for the XML schema used in the `xsi:noNamespaceSchemaLocation` attribute of ruleset files. This replaces the previous `raw.githubusercontent.com` URL with https://schema.phpcodesniffer.com/phpcs.xsd.

See:
* https://github.com/squizlabs/PHP_CodeSniffer/issues/3932
* https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated configuration schema reference to use the canonical host
  * Updated dependency documentation with current repository information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->